### PR TITLE
Improve incompatible unit error message

### DIFF
--- a/lib/unit/class.rb
+++ b/lib/unit/class.rb
@@ -55,7 +55,7 @@ class Unit < Numeric
   end
 
   def +(other)
-    raise TypeError, 'Incompatible units' if !compatible?(other)
+    raise TypeError, "Incompatible units: #{self.inspect} and #{other.inspect}" if !compatible?(other)
     a, b = coerce(other)
     a, b = a.normalize, b.normalize
     Unit.new(a.value + b.value, a.unit, system).in(self)

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+require 'bacon'
+require 'unit'
+require 'unit/dsl'
+
+describe "Errors" do
+  describe "TypeError when adding incompatible units" do
+    it "should have a nice error message" do
+      unit_1 = Unit(1, "meter")
+      unit_2 = Unit(1, "second")
+      lambda {
+        unit_1 + unit_2
+      }.should.raise(TypeError).message.should.equal("Incompatible units: #{unit_1.inspect} and #{unit_2.inspect}")
+    end
+  end
+end


### PR DESCRIPTION
``` ruby
Unit(2, "meters") + Unit(3, "seconds")
#=> TypeError: Incompatible units: Unit("2 m") and Unit("3 s")
```
