### PR TITLE
Add load system with hash

### DIFF
--- a/lib/unit/system.rb
+++ b/lib/unit/system.rb
@@ -20,6 +20,9 @@ class Unit < Numeric
 
     def load(input)
       case input
+      when Hash
+        raise "Invalid hash format to load system" unless (input["units"] && input["units"].first.last['def']) || input.first.last['def']
+        data = input['units'] || input
       when IO
         data = YAML.load(input.read)
       when String

--- a/test/system_test.rb
+++ b/test/system_test.rb
@@ -19,6 +19,16 @@ describe "Unit" do
         Unit.default_system.load(test_file)
         Unit(2, "dzm").should.equal Unit(24, "m")
       end
+
+      it "should load a hash" do
+        Unit.default_system.load({
+          'dozen_meter' => {
+            'sym' => 'dzm',
+            'def' => '12 m'
+          }
+        })
+        Unit(2, "dzm").should.equal Unit(24, "m")
+      end
     end
   end
 end


### PR DESCRIPTION
You can now load a system with a hash

```
    Unit.default_system.load({
      'dozen_meter' => {
        'sym' => 'dzm',
        'def' => '12 m'
      }
    })
```
