### PR TITLE
Improvements to Unit::System#load

### DIFF
--- a/lib/unit/system.rb
+++ b/lib/unit/system.rb
@@ -15,6 +15,9 @@ class Unit < Numeric
       @factor_symbol = {'one' => :one}
       @factor_value = {1 => :one}
 
+      @loaded_systems = []
+      @loaded_filenames = []
+
       yield(self) if block_given?
     end
 
@@ -26,13 +29,17 @@ class Unit < Numeric
         data = YAML.load(input.read)
       when String
         if File.exist?(input)
+          return if @loaded_filenames.include?(input)
           data = YAML.load_file(input)
+          @loaded_filenames << input
         else
           load(input.to_sym)
           return
         end
       when Symbol
+        return if @loaded_systems.include?(input)
         data = YAML.load_file(File.join(File.dirname(__FILE__), 'systems', "#{input}.yml"))
+        @loaded_systems << input
       end
 
       load_factors(data['factors']) if data['factors']

--- a/spec/system_spec.rb
+++ b/spec/system_spec.rb
@@ -76,5 +76,23 @@ describe Unit::System do
         end
       end
     end
+
+    context "when called on the same filename a second time" do
+      it "should be a no-op" do
+        $stderr.should_not_receive(:puts)
+        test_file = File.join(File.dirname(__FILE__), "yml", "filename.yml")
+        system.load(:si)
+        system.load(test_file)
+        lambda { system.load(test_file) }.should_not raise_exception
+      end
+    end
+
+    context "when called on the same symbol a second time" do
+      it "should be a no-op" do
+        $stderr.should_not_receive(:puts)
+        system.load(:si)
+        lambda { system.load(:si) }.should_not raise_exception
+      end
+    end
   end
 end


### PR DESCRIPTION
We added some test coverage, pulled out some private methods, and made it possible to call `load` on the same filename or symbol multiple times without getting a warning.
