### PR TITLE
Better handling of Rational values in #to_s

### DIFF
--- a/lib/unit/class.rb
+++ b/lib/unit/class.rb
@@ -159,11 +159,11 @@ class Unit < Numeric
   end
 
   def inspect
-    unit.empty? ? %{Unit("#{value}")} : %{Unit("#{value} #{unit_string('.')}")}
+    unit.empty? ? %{Unit("#{value}")} : %{Unit("#{value_string} #{unit_string('.')}")}
   end
 
   def to_s
-    unit.empty? ? value.to_s : "#{value} #{unit_string}"
+    unit.empty? ? value.to_s : "#{value_string} #{unit_string}"
   end
 
   def to_tex
@@ -188,6 +188,18 @@ class Unit < Numeric
 
   def coerce(other)
     [coerce_numeric(other), self]
+  end
+
+  def value_string
+    if Rational === value
+      if value.denominator == 1
+        value.numerator.to_s
+      else
+        value.inspect
+      end
+    else
+      value.to_s
+    end
   end
 
   def unit_string(sep = '·')

--- a/spec/unit_spec.rb
+++ b/spec/unit_spec.rb
@@ -153,6 +153,26 @@ describe 'Unit' do
     (Unit('5 cm') - Unit('1 cm')).to_s.should == '4 cm'
   end
 
+  describe "#value_string" do
+    it 'should behave like to_s normally' do
+      Unit(1, "liter").send(:value_string).should == "1"
+      Unit(0.5, "parsec").send(:value_string).should == "0.5"
+    end
+
+    it 'should wrap fractions in parentheses' do
+      Unit(Rational(1, 2), "m").send(:value_string).should == "(1/2)"
+    end
+
+    it 'should show reduced fractions' do
+      Unit(Rational(16, 6), "m").send(:value_string).should == "(8/3)"
+    end
+
+    it 'should not show 1 in the denominator' do
+      Unit(Rational(1), "foot").send(:value_string).should == "1"
+      Unit(Rational(4, 1), "inch").send(:value_string).should == "4"
+    end
+  end
+
   it 'should support round trip through to_s' do
     Unit(Unit('(1/2) cm').to_s).should == Unit('(1/2) cm')
   end

--- a/spec/unit_spec.rb
+++ b/spec/unit_spec.rb
@@ -149,6 +149,14 @@ describe 'Unit' do
     Unit(7, "joule").normalize.to_s.should == '7000 g·m^2·s^-2'
   end
 
+  it 'should have a pretty string representation after subtraction' do
+    (Unit('5 cm') - Unit('1 cm')).to_s.should == '4 cm'
+  end
+
+  it 'should support round trip through to_s' do
+    Unit(Unit('(1/2) cm').to_s).should == Unit('(1/2) cm')
+  end
+
   it 'should parse units' do
     Unit(1, 'KiB s^-1').unit.should == [[:kibi, :byte, 1], [:one, :second, -1]].sort
     Unit(1, 'KiB/s').unit.should == [[:kibi, :byte, 1], [:one, :second, -1]].sort


### PR DESCRIPTION
Added `#value_string` to parallel `#unit_string`, which does two things when the value is `Rational`:

- If the denominator is 1, don't show it.
- Otherwise, wrap the value in parentheses so that it can be parsed properly.

Also added specs for two cases that would fail previously.

Should fix #22.