### PR TITLE
Fix failing rspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.0
   - ruby-head
-  - jruby-18mode
-  - jruby-19mode
-  - rbx

--- a/lib/unit/dsl.rb
+++ b/lib/unit/dsl.rb
@@ -5,6 +5,8 @@ class Numeric
 
   def method_missing(name, system = nil)
     Unit.to_unit(Unit.method_name_to_unit(name), system) * self
+  rescue TypeError
+    super
   end
 end
 

--- a/unit.gemspec
+++ b/unit.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.authors = ["Daniel Mendler", "Chris Cashwell"]
-  s.date  = Date.today.to_s
+  s.date  = Time.now.strftime('%Y-%m-%d')
   s.email = ["mail@daniel-mendler.de"]
 
   s.rubyforge_project = s.name


### PR DESCRIPTION
As I understand it, rspec was trying to call #to_ary on some numeric values for formatting (not sure the details there). This was hitting method_missing and trying to convert the method name to a unit. Now calls super if the method name isn't defined as a unit.
