### PR TITLE
Treat empty unit string as dimensionless in conversions

### DIFF
--- a/lib/unit/system.rb
+++ b/lib/unit/system.rb
@@ -60,6 +60,30 @@ class Unit < Numeric
       end
     end
 
+    # Parse a unit expression into a unit definition: an array of
+    # <tt>[factor, unit, exponent]</tt> triples suitable for +Unit.new+ and
+    # +validate_unit+.
+    #
+    # The expression is tokenized (see +TOKENIZER+) and evaluated with a
+    # shunting-yard pass over +OPERATOR+, supporting multiplication
+    # (<tt>*</tt>, <tt>·</tt>, or juxtaposition), division (<tt>/</tt>),
+    # exponentiation (<tt>^</tt>, <tt>**</tt>), grouping parentheses, and
+    # numeric literals.
+    #
+    #   system.parse_unit("m/s^2")  # => [[:one, 1, 1], [:meter, ..., 1], [:second, ..., -2]]
+    #
+    # An empty or whitespace-only expression has no tokens and yields the
+    # *dimensionless* unit <tt>[]</tt> — the same definition produced by
+    # <tt>Unit(1, "")</tt> — so conversion stays consistent with construction
+    # rather than returning +nil+.
+    #
+    #   system.parse_unit("")    # => []
+    #   system.parse_unit("  ")  # => []
+    #
+    # Unrecognized glyphs survive lexing (see +SYMBOL+) and fail loudly as an
+    # "Undefined unit" +TypeError+ during validation rather than being dropped.
+    #
+    # Raises +SyntaxError+ on unbalanced parentheses.
     def parse_unit(expr)
       stack, result, implicit_mul = [], [], false
       expr.to_s.scan(TOKENIZER).each do |tok|
@@ -87,7 +111,7 @@ class Unit < Numeric
         end
       end
       compute(result, stack.pop) while !stack.empty?
-      result.last
+      result.last || []
     end
 
     private

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -26,4 +26,27 @@ describe "Errors" do
     end
   end
 
+  describe "converting to an empty (dimensionless) unit string" do
+    it "treats #in(\"\") as the dimensionless unit" do
+      expect(Unit(1, "").in("")).to eq(Unit(1, ""))
+    end
+
+    it "treats #in(\" \") (whitespace-only) as the dimensionless unit" do
+      expect(Unit(1, "").in(" ")).to eq(Unit(1, ""))
+    end
+
+    it "treats #in!(\"\") as the dimensionless unit" do
+      expect(Unit(1, "").in!("")).to eq(Unit(1, ""))
+    end
+
+    it "treats #in!(\" \") (whitespace-only) as the dimensionless unit" do
+      expect(Unit(1, "").in!(" ")).to eq(Unit(1, ""))
+    end
+
+    it "raises a clean TypeError (not NoMethodError) from #in! for an incompatible unit" do
+      unit = Unit(5, "m/s")
+      expect { unit.in!("") }.to raise_error(TypeError)
+    end
+  end
+
 end

--- a/spec/system_spec.rb
+++ b/spec/system_spec.rb
@@ -172,4 +172,16 @@ describe Unit::System do
       expect(Unit(1, "MeV", system).unit).to eq(Unit(1, "megaelectronvolt", system).unit)
     end
   end
+
+  describe "#parse_unit with an empty or whitespace-only expression" do
+    before { system.load(:si) }
+
+    it "returns [] (the dimensionless unit) for an empty string" do
+      expect(system.parse_unit("")).to eq([])
+    end
+
+    it "returns [] (the dimensionless unit) for a whitespace-only string" do
+      expect(system.parse_unit("  ")).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`Unit#in!("")` (and `in!(" ")`, and the same via `#in`) crashed with
`NoMethodError: undefined method 'each' for nil` instead of behaving like the
dimensionless unit. Construction already treats an empty unit string as
dimensionless (`Unit(1, "")  # => Unit("1")`), so conversion was **inconsistent
with construction** for the same input.

```ruby
Unit(1, "")          # => Unit("1")    construction: "" is dimensionless, fine
Unit(1, "").in!(nil) # => TypeError    clean (coercion guard)
Unit(1, "").in!("")  # => NoMethodError: undefined method 'each' for nil   BUG
Unit(1, "").in!(" ") # => NoMethodError: undefined method 'each' for nil   BUG
```

A `rescue TypeError` around a conversion used as a dimensional guard therefore
did not catch the empty-string case — it slipped past the coercion guard and
crashed deeper.

## Root cause

`Unit::System#parse_unit` returned `result.last`. For an empty or
whitespace-only expression the tokenizer yields no tokens, so `result` is `[]`
and `result.last` is `nil`. `validate_unit` then called `nil.each`.

## Fix

Make `parse_unit` total: an empty / whitespace-only expression yields the
dimensionless unit definition `[]` (the shape every consumer — `to_unit`, the
constructor, `validate_unit` — already accepts) rather than `nil`. So:

```ruby
Unit(1, "").in("")   # => Unit("1")     now matches construction
Unit(1, "").in!("")  # => Unit("1")
Unit(1, "").in!(" ") # => Unit("1")
Unit(5, "m/s").in!("") # => TypeError   clean, not NoMethodError
```

## Test plan

- [x] `bundle exec rake` — both phases green (160 no-DSL + 162 DSL examples, 0 failures)
- [x] New specs cover `#in("")` / `#in(" ")` and `#in!("")` / `#in!(" ")` returning
  the dimensionless unit, a clean `TypeError` from `#in!` for an incompatible unit,
  and `parse_unit("")` / `parse_unit("  ")` returning `[]`
