### PR TITLE
Add Unit#value_in for bare-value conversion

### DIFF
--- a/lib/unit/class.rb
+++ b/lib/unit/class.rb
@@ -289,6 +289,17 @@ class Unit < Numeric
     result
   end
 
+  # Converts +self+ to +unit+ and returns the bare numeric value, dropping
+  # the dimension. Builds on +#in!+, so a dimensionally incompatible +unit+
+  # raises +TypeError+ rather than returning a coerced number with residual
+  # units.
+  #
+  #   Unit(1, "kilometer").value_in("meter")  # => 1000
+  #   Unit(1, "meter").value_in("volt")       # raises TypeError
+  def value_in(unit)
+    in!(unit).value
+  end
+
   def inspect
     unit.empty? ? %{Unit("#{value}")} : %{Unit("#{value_string} #{unit_string('.')}")}
   end

--- a/spec/unit_spec.rb
+++ b/spec/unit_spec.rb
@@ -262,6 +262,15 @@ describe 'Unit' do
     expect(Unit(1, "kilometer/hour").in("meter/second")).to eq(Unit(5, 18, 'meter/second'))
   end
 
+  it 'should extract the bare value in a target unit' do
+    expect(Unit(1, "kilometer").value_in("meter")).to eq(1000)
+    expect(Unit(1, "kilometer/hour").value_in("meter/second")).to eq(Rational(5, 18))
+  end
+
+  it 'should raise when value_in is given an incompatible unit' do
+    expect { Unit(1, "meter").value_in("second") }.to raise_error(TypeError)
+  end
+
   it 'should have a working compatible? method' do
     expect(Unit(7, "meter").compatible?('kilogram')).to eq(false)
     expect(Unit(3, "parsec").compatible_with?('meter')).to eq(true)


### PR DESCRIPTION
`Unit#in` returns a converted `Unit` and `Unit#in!` raises on a dimensionally incompatible target, but neither yields the raw number in the requested unit without a caller peeling off `#value` by hand.

`Unit#value_in(unit)` converts via `#in!` and returns the bare numeric value, so an incompatible unit raises `TypeError` rather than handing back a coerced number with residual dimensions.

```ruby
Unit(1, "kilometer").value_in("meter")       # => 1000
Unit(1, "kilometer/hour").value_in("meter/second")  # => (5/18)
Unit(1, "meter").value_in("second")          # raises TypeError
```