### PR TITLE
Bump actions/checkout to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           - head
     continue-on-error: ${{ matrix.ruby == 'head' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}


### PR DESCRIPTION
`actions/checkout@v4` runs on Node 20, which GitHub is deprecating. Bump to v7 (Node 24).

`ruby/setup-ruby@v1` is left as-is — `v1` is the maintained floating major.